### PR TITLE
Refactor: Centralize API route definitions

### DIFF
--- a/src/CostructionManagementAssistant_API/Controllers/DocumentClassificationsController.cs
+++ b/src/CostructionManagementAssistant_API/Controllers/DocumentClassificationsController.cs
@@ -4,12 +4,11 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace ConstructionManagementAssistant.API.Controllers
 {
-    [Route("api/[controller]")]
     [ApiController]
     public class DocumentClassificationsController(IUnitOfWork _unitOfWork) : ControllerBase
     {
        
-        [HttpPost("{type}")]
+        [HttpPost(SystemApiRouts.DocumentClassifications.AddDocumentClassification)]
         public async Task<IActionResult> CreateAsync([FromRoute] string type)
         {
             var response = await _unitOfWork.DocumentClassifications.CreateAsync(type);
@@ -19,17 +18,17 @@ namespace ConstructionManagementAssistant.API.Controllers
             return Ok(response);
         }
 
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetAsync(int id)
+        [HttpGet(SystemApiRouts.DocumentClassifications.GetDocumentClassificationById)]
+        public async Task<IActionResult> GetAsync(int Id)
         {
-            var response = await _unitOfWork.DocumentClassifications.GetAsync(id);
+            var response = await _unitOfWork.DocumentClassifications.GetAsync(Id);
             if (!response.Success)
                 return NotFound(response);
 
             return Ok(response);
         }
 
-        [HttpGet]
+        [HttpGet(SystemApiRouts.DocumentClassifications.GetAllDocumentClassifications)]
         public async Task<IActionResult> GetAllAsync()
         {
             var response = await _unitOfWork.DocumentClassifications.GetAllAsync();
@@ -39,7 +38,7 @@ namespace ConstructionManagementAssistant.API.Controllers
             return Ok(response);
         }
 
-        [HttpPut]
+        [HttpPut(SystemApiRouts.DocumentClassifications.UpdateDocumentClassification)]
         public async Task<IActionResult> UpdateAsync([FromBody] DocumentClassification type)
         {
             var response = await _unitOfWork.DocumentClassifications.UpdateAsync(type);
@@ -49,10 +48,10 @@ namespace ConstructionManagementAssistant.API.Controllers
             return Ok(response);
         }
 
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteAsync(int id)
+        [HttpDelete(SystemApiRouts.DocumentClassifications.DeleteDocumentClassification)]
+        public async Task<IActionResult> DeleteAsync(int Id)
         {
-            var response = await _unitOfWork.DocumentClassifications.DeleteAsync(id);
+            var response = await _unitOfWork.DocumentClassifications.DeleteAsync(Id);
             if (!response.Success)
                 return BadRequest(response);
 

--- a/src/CostructionManagementAssistant_API/Controllers/DocumentsController.cs
+++ b/src/CostructionManagementAssistant_API/Controllers/DocumentsController.cs
@@ -4,11 +4,10 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace ConstructionManagementAssistant.API.Controllers
 {
-    [Route("api/[controller]")]
     [ApiController]
     public class DocumentsController(IUnitOfWork _unitOfWork) : ControllerBase
     {
-        [HttpPost("upload")]
+        [HttpPost(SystemApiRouts.Documents.UploadDocument)]
         public async Task<IActionResult> UploadDocument([FromForm]UploadFileRequest document)
         {
             if (document == null || document.File == null)
@@ -24,7 +23,7 @@ namespace ConstructionManagementAssistant.API.Controllers
             return Ok(result);
         }
 
-        [HttpGet]
+        [HttpGet(SystemApiRouts.Documents.GetAllDocuments)]
         public async Task<IActionResult> GetAllDocs(int projectId,
                                                     int? TaskId = null,
                                                     int pageNumber = 1,
@@ -50,7 +49,7 @@ namespace ConstructionManagementAssistant.API.Controllers
             });
         }
 
-        [HttpGet("{Id:guid}")]
+        [HttpGet(SystemApiRouts.Documents.GetDocumentById)]
         public async Task<IActionResult> GetDocumentById(Guid Id)
         {
             var result = await _unitOfWork.Documents.GetDocumentByIdAsync(Id);
@@ -69,7 +68,7 @@ namespace ConstructionManagementAssistant.API.Controllers
             });
         }
 
-        [HttpPut]
+        [HttpPut(SystemApiRouts.Documents.UpdateDocument)]
         public async Task<IActionResult> UpdateClient(UpdateDocumentRequest payload)
         {
             var result = await _unitOfWork.Documents.UpdateDocumentAsync(payload);
@@ -78,7 +77,7 @@ namespace ConstructionManagementAssistant.API.Controllers
             return Ok(result);
         }
 
-        [HttpDelete("{Id:guid}")]
+        [HttpDelete(SystemApiRouts.Documents.DeleteDocument)]
         public async Task<IActionResult> DeleteDocument(Guid Id)
         {
             var result = await _unitOfWork.Documents.DeleteDocumentAsync(Id);

--- a/src/CostructionManagementAssistant_API/Helper/SystemApiRouts.cs
+++ b/src/CostructionManagementAssistant_API/Helper/SystemApiRouts.cs
@@ -125,4 +125,25 @@ public static class SystemApiRouts
 
     }
 
+    public class Documents
+    {
+        public const string Base = "api/v1/Documents";
+        public const string GetDocumentById = Base + "/{Id}";
+        public const string GetAllDocuments = Base;
+        public const string UploadDocument = Base;
+        public const string UpdateDocument = Base;
+        public const string DeleteDocument = Base + "/{Id}";
+
+    }
+
+    public class DocumentClassifications
+    {
+        public const string Base = "api/v1/DocumentClassifications";
+        public const string GetDocumentClassificationById = Base + "/{Id}";
+        public const string GetAllDocumentClassifications = Base;
+        public const string AddDocumentClassification = Base;
+        public const string UpdateDocumentClassification = Base;
+        public const string DeleteDocumentClassification = Base + "/{Id}";
+
+    }
 }


### PR DESCRIPTION
Updated `DocumentClassificationsController` and `DocumentsController` to use centralized route constants from the new `SystemApiRouts` class. Introduced `SystemApiRouts` with standardized route definitions for maintainability and consistency. Standardized parameter naming in `DocumentClassificationsController` to align with conventions.